### PR TITLE
fix(index): typeError - Cannot read property 'body' of undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -378,6 +378,7 @@ function deliverPlain(owner, repo, ref, entry, root, esi = false, branch) {
     if (rqerror.statusCode === 404 || rqerror.statusCode === '404') {
       return error(entry, rqerror.statusCode);
     }
+    log.error('error while fetching content', rqerror);
     return error(
       (rqerror.response && rqerror.response.body && rqerror.response.body.toString())
       || rqerror.message,

--- a/src/index.js
+++ b/src/index.js
@@ -378,7 +378,11 @@ function deliverPlain(owner, repo, ref, entry, root, esi = false, branch) {
     if (rqerror.statusCode === 404 || rqerror.statusCode === '404') {
       return error(entry, rqerror.statusCode);
     }
-    return error(rqerror.response.body.toString(), rqerror.statusCode);
+    return error(
+      (rqerror.response && rqerror.response.body && rqerror.response.body.toString())
+      || rqerror.message,
+      rqerror.statusCode,
+    );
   });
 }
 


### PR DESCRIPTION
This PR fixes the following error which we see occasionally:

```
TypeError: Cannot read property 'body' of undefined
    at request.get.then.catch (/nodejsAction/XXAAJLNb/main.js:230741:35)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

This error hides the underlying issue. With this fix we should see the real issue.