### PR TITLE
fix(plain): don't encode binary response

### DIFF
--- a/src/handlers/github-plain.js
+++ b/src/handlers/github-plain.js
@@ -10,28 +10,9 @@
  * governing permissions and limitations under the License.
  */
 const { fetchFromGithub } = require('../github-fetcher');
-const { isBinary, isJSON } = require('../utils');
-
-/**
- * Processes the body according to the content type.
- * @param {string} type - the content type
- * @param {Buffer} responsebody - the response body
- * @param {boolean} esi - esi flag
- * @param {string} entry - the base href
- * @returns {Function|any|string|any} the response body
- */
-function processBody(responsebody, { type }) {
-  if (isBinary(type)) {
-    return responsebody.toString('base64');
-  }
-  if (isJSON(type)) {
-    return JSON.parse(responsebody.toString('utf-8'));
-  }
-  return responsebody.toString('utf-8');
-}
 
 function handle(opts) {
-  return fetchFromGithub(opts, processBody);
+  return fetchFromGithub(opts, null);
 }
 
 module.exports = handle;

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,36 +15,6 @@ const sanitizer = require('sanitizer');
 const log = require('@adobe/helix-log');
 
 /**
- * Checks if the content type is JSON.
- * @param {string} type - content type
- * @returns {boolean} {@code true} if content type is JSON.
- */
-function isJSON(type) {
-  return /json/.test(type);
-}
-
-/**
- * Checks if the content type is binary.
- * @param {string} type - content type
- * @returns {boolean} {@code true} if content type is binary.
- */
-function isBinary(type) {
-  if (/text\/.*/.test(type)) {
-    return false;
-  }
-  if (/.*\/javascript/.test(type)) {
-    return false;
-  }
-  if (/.*\/.*json/.test(type)) {
-    return false;
-  }
-  if (/.*\/.*xml/.test(type)) {
-    return /svg/.test(type); // openwshisk treats SVG as binary
-  }
-  return true;
-}
-
-/**
  * Checks if the content type is css.
  * @param {string} type - content type
  * @returns {boolean} {@code true} if content type is css.
@@ -96,5 +66,5 @@ function forbidden() {
 }
 
 module.exports = {
-  error, forbidden, isJSON, isJavaScript, isCSS, isBinary,
+  error, forbidden, isJavaScript, isCSS,
 };

--- a/test/font-proxy.test.js
+++ b/test/font-proxy.test.js
@@ -121,6 +121,7 @@ describe('Adobe Fonts Proxy Test #unitttest', () => {
 
   it('Delivers rewritten Kit', async () => {
     const res = retrofitResponse(await deliverFontCSS({ params: { kitid: 'eic8tkf' } }));
+    res.body = String(res.body);
     assert.equal(res.headers['cache-control'], 'private, max-age=600, stale-while-revalidate=604800');
     assert.ok(!res.body.match(/https:\/\/use.typekit\.net/));
     assert.ok(!res.body.match(/https:\/\/p.typekit\.net/));

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -35,19 +35,14 @@ createTargets().forEach((target) => {
         .get(`${target.urlPath()}?owner=adobe&repo=ferrumjsorg&ref=54d751f37633fa777ce0816390b3bdbe515d0295&path=/index.html&branch=master&params=`)
         .then((response) => {
           url = response.request.url;
-
-          expect(response)
-            .to
-            .have
-            .status(200);
+          expect(response).to.have.status(200);
           expect(response).to.be.html;
         })
         .catch((e) => {
           e.message = `At ${url}\n      ${e.message}`;
           throw e;
         });
-    })
-      .timeout(10000);
+    }).timeout(10000);
 
     it('theblog/sitemap.xml gets delivered', async () => {
       let url;
@@ -57,16 +52,46 @@ createTargets().forEach((target) => {
         .get(`${target.urlPath()}?owner=adobe&repo=theblog&ref=7966963696682b955c13ac0cefb8ed9af065f66a&path=/sitemap.xml&branch=staging&params=`)
         .then((response) => {
           url = response.request.url;
-
-          expect(response)
-            .to
-            .redirectTo('https://raw.githubusercontent.com/adobe/theblog/7966963696682b955c13ac0cefb8ed9af065f66a/sitemap.xml');
+          expect(response).to.redirectTo('https://raw.githubusercontent.com/adobe/theblog/7966963696682b955c13ac0cefb8ed9af065f66a/sitemap.xml');
         })
         .catch((e) => {
           e.message = `At ${url}\n      ${e.message}`;
           throw e;
         });
-    })
-      .timeout(10000);
+    }).timeout(10000);
+
+    it('pages/icons.svg gets delivered', async () => {
+      let url;
+      await chai
+        .request(target.host())
+        .get(`${target.urlPath()}?owner=adobe&repo=pages&ref=d7acb4e41cf9546a40c7d6cd5e7162f8bcd540fd&path=/icons.svg`)
+        .then((response) => {
+          url = response.request.url;
+          expect(response).to.have.status(200);
+          expect(response).to.have.header('content-type', 'image/svg+xml');
+          expect(response.body.toString()).to.be.a('string').that.includes('<?xml version="1.0" encoding="utf-8"?>');
+        })
+        .catch((e) => {
+          e.message = `At ${url}\n      ${e.message}`;
+          throw e;
+        });
+    }).timeout(10000);
+
+    it('helix-pages/htdocs/favicon.ico gets delivered', async () => {
+      let url;
+      await chai
+        .request(target.host())
+        .get(`${target.urlPath()}?owner=adobe&repo=helix-pages&ref=f919cff9cd664283b64da854f22382588c3f1c33&path=/htdocs/favicon.ico`)
+        .then((response) => {
+          url = response.request.url;
+          expect(response).to.have.status(200);
+          expect(response).to.have.header('content-type', 'image/vnd.microsoft.icon');
+          expect(response.body.toString('base64')).to.includes('iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAD');
+        })
+        .catch((e) => {
+          e.message = `At ${url}\n      ${e.message}`;
+          throw e;
+        });
+    }).timeout(10000);
   });
 });

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -93,5 +93,22 @@ createTargets().forEach((target) => {
           throw e;
         });
     }).timeout(10000);
+
+    it('trieloff/helix-demo/htdocs/test.json gets delivered', async () => {
+      let url;
+      await chai
+        .request(target.host())
+        .get(`${target.urlPath()}?owner=trieloff&repo=helix-demo&ref=83afa4fdee57868e2cc6c5068d742f59c066d367&path=/htdocs/test.json`)
+        .then((response) => {
+          url = response.request.url;
+          expect(response).to.have.status(200);
+          expect(response).to.be.json;
+          expect(response.body).to.deep.equal({ foo: 'bar' });
+        })
+        .catch((e) => {
+          e.message = `At ${url}\n      ${e.message}`;
+          throw e;
+        });
+    }).timeout(10000);
   });
 });

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -119,7 +119,7 @@ describe('Static Delivery Action #integrationtest', () => {
     assert.equal(res.headers['x-static'], 'Raw/Static');
     assert.equal(res.headers['cache-control'], 's-maxage=300, stale-while-revalidate=2592000');
     assert.equal(res.headers['surrogate-key'], 'LiWDcUs5H72QTkGl');
-    assert.equal(res.headers.etag, '"VIXMjwsHOMPLZGtviFum1TGBFMz6zCQKINQseZ6Ub6k="');
+    assert.equal(res.headers.etag, '"zei2DOT55/ukAFvbmB1QwDy2e3KnWuXg41yw2R6TRng="');
   });
 
   it('deliver JSON file', async () => {
@@ -136,7 +136,7 @@ describe('Static Delivery Action #integrationtest', () => {
     assert.equal(res.headers['x-static'], 'Raw/Static');
     assert.equal(res.headers['cache-control'], 's-maxage=300, stale-while-revalidate=2592000');
     assert.equal(res.headers['surrogate-key'], 'CIUWTRUuAYPY51zR');
-    assert.equal(res.headers.etag, '"hNCISMWqyUDaDY2zDTMKXb1peyzXunKE791FEtjILtg="');
+    assert.equal(res.headers.etag, '"uc0mBep1KTsWuJKpfF5LC8GPPa/Qy9+JfIAljVdBXIA="');
   });
 
   it('deliver missing file', async () => {
@@ -306,18 +306,6 @@ describe('Static Delivery Action #unittest', () => {
 
     const afterSha = gh.addHeaders(before, 'bcdcc24e8ebc25a07a35d05afd85551a83fa5af3', 'foobar');
     assert.ok(afterSha['Cache-Control'].match(/^max-age/));
-  });
-
-  it('isBinary() #unittest', () => {
-    assert.equal(utils.isBinary('application/octet-stream'), true);
-    assert.equal(utils.isBinary('image/png'), true);
-    assert.equal(utils.isBinary('un/known'), true);
-    assert.equal(utils.isBinary('image/svg+xml'), true);
-
-    assert.equal(utils.isBinary('text/html'), false);
-    assert.equal(utils.isBinary('text/xml'), false);
-    assert.equal(utils.isBinary('application/json'), false);
-    assert.equal(utils.isBinary('application/javascript'), false);
   });
 
   it('rejected() #unittest', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -12,15 +12,9 @@
 const querystring = require('querystring');
 
 function retrofitResponse(resp) {
-  let body = resp.body ? String(resp.body) : null;
-  try {
-    body = JSON.parse(body);
-  } catch {
-    // ignore
-  }
   return {
     statusCode: resp.status,
-    body,
+    body: resp.body,
     headers: [...resp.headers.keys()].reduce((result, key) => {
       // eslint-disable-next-line no-param-reassign
       result[key] = resp.headers.get(key);


### PR DESCRIPTION
fixes #450

**Note**: the response from github doesn't need to be base64 encoded if it's binary, since this is now handled by the adapter. in the ideal case, it can just return the response buffer form the github fetch request.