### PR TITLE
Support rootless setups

### DIFF
--- a/src/handlers/font-css.js
+++ b/src/handlers/font-css.js
@@ -31,7 +31,7 @@ async function getSanitizedCssAndUrls(cssToSanitize) {
         format: rule.replace(/.*format\(["']([^"']*)["']\).*/, '$1'),
       })).filter((rule) => rule.format === 'woff2')
         .map((rule) => rule.url)
-        .map((body) => body.replace(/https:\/\/use\.typekit\.net\//g, '/hlx_fonts/'));
+        .map((body) => body.replace(/https:\/\/use\.typekit\.net\//g, './fonts.hlx/'));
       foundurls.push(...urls);
 
       // Add swap before replacing the src
@@ -42,7 +42,7 @@ async function getSanitizedCssAndUrls(cssToSanitize) {
       decl.replaceWith(postcss.decl(
         {
           prop: 'src',
-          value: decl.value.replace(/https:\/\/use\.typekit\.net\//g, '/hlx_fonts/'),
+          value: decl.value.replace(/https:\/\/use\.typekit\.net\//g, './fonts.hlx/'),
         },
       ));
     });

--- a/src/static.js
+++ b/src/static.js
@@ -104,7 +104,8 @@ async function deliverStatic(req, context) {
   params.githubToken = params.GITHUB_TOKEN || req.headers.get('x-github-token');
 
   return router
-    .register('/hlx_fonts/:kitid([a-z0-9]{7}).css', fontCSS)
+    .register('/hlx_fonts/:kitid([a-z0-9]{7}).css', fontCSS.absolute)
+    .register(':path(.*)/fonts.hlx/:kitid([a-z0-9]{7}).css', fontCSS)
     .register(':path(.*).:ext(css)', githubCSS, isESI)
     .register(':path(.*).:ext(m?js)', githubJS, isESI)
     .register(':path(.*).:ext(.*)', githubPlain)

--- a/test/font-proxy.test.js
+++ b/test/font-proxy.test.js
@@ -101,7 +101,7 @@ describe('Adobe Fonts CSS Parser', () => {
 
     const res = await getSanitizedCssAndUrls(css);
     assert.ok(Array.isArray(res.foundurls));
-    assert.equal(res.foundurls[0], '/hlx_fonts/af/d91a29/00000000000000003b9af759/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i4&v=3');
+    assert.equal(res.foundurls[0], './fonts.hlx/af/d91a29/00000000000000003b9af759/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i4&v=3');
   });
 });
 
@@ -126,9 +126,9 @@ describe('Adobe Fonts Proxy Test #unitttest', () => {
     assert.ok(!res.body.match(/https:\/\/use.typekit\.net/));
     assert.ok(!res.body.match(/https:\/\/p.typekit\.net/));
     assert.ok(res.body.indexOf('font-display:swap' > -1));
-    assert.ok(res.body.match(/\/hlx_fonts\//));
+    assert.ok(res.body.match(/\/fonts\.hlx\//));
     assert.equal(res.statusCode, 200);
-    assert.equal(res.headers.link, '</hlx_fonts/af/d91a29/00000000000000003b9af759/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i4&v=3>; rel=preload; as=font; crossorigin=anonymous,</hlx_fonts/af/c5b4b1/00000000000000003b9af75a/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=n4&v=3>; rel=preload; as=font; crossorigin=anonymous,</hlx_fonts/af/c52cc9/00000000000000003b9af75d/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i7&v=3>; rel=preload; as=font; crossorigin=anonymous,</hlx_fonts/af/d6053e/00000000000000003b9af75e/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=n7&v=3>; rel=preload; as=font; crossorigin=anonymous,</hlx_fonts/af/68fa2f/00000000000000003b9af764/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=n4&v=3>; rel=preload; as=font; crossorigin=anonymous,</hlx_fonts/af/bd7e57/00000000000000003b9af765/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i4&v=3>; rel=preload; as=font; crossorigin=anonymous,</hlx_fonts/af/056440/00000000000000003b9af768/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i7&v=3>; rel=preload; as=font; crossorigin=anonymous,</hlx_fonts/af/9d03dd/00000000000000003b9af769/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=n7&v=3>; rel=preload; as=font; crossorigin=anonymous');
+    assert.equal(res.headers.link, '<./fonts.hlx/af/d91a29/00000000000000003b9af759/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i4&v=3>; rel=preload; as=font; crossorigin=anonymous,<./fonts.hlx/af/c5b4b1/00000000000000003b9af75a/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=n4&v=3>; rel=preload; as=font; crossorigin=anonymous,<./fonts.hlx/af/c52cc9/00000000000000003b9af75d/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i7&v=3>; rel=preload; as=font; crossorigin=anonymous,<./fonts.hlx/af/d6053e/00000000000000003b9af75e/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=n7&v=3>; rel=preload; as=font; crossorigin=anonymous,<./fonts.hlx/af/68fa2f/00000000000000003b9af764/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=n4&v=3>; rel=preload; as=font; crossorigin=anonymous,<./fonts.hlx/af/bd7e57/00000000000000003b9af765/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i4&v=3>; rel=preload; as=font; crossorigin=anonymous,<./fonts.hlx/af/056440/00000000000000003b9af768/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i7&v=3>; rel=preload; as=font; crossorigin=anonymous,<./fonts.hlx/af/9d03dd/00000000000000003b9af769/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=n7&v=3>; rel=preload; as=font; crossorigin=anonymous');
   });
 
   it('Delivers 404 for missing kit', async () => {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -18,6 +18,45 @@ const { retrofit } = require('./utils.js');
 const main = retrofit(universalMain);
 
 /* eslint-env mocha */
+
+describe('Font Proxy Integration Tests #online #integrationtest', () => {
+  it('adobe/theblog fonts get delivered with absolute URL', async () => {
+    const res = await main({
+      ref: '7966963696682b955c13ac0cefb8ed9af065f66a',
+      package: '8c8a56985d9b2624d338e98af8ba8cf03124dc11',
+      path: '/hlx_fonts/pnv6nym.css',
+      params: '',
+      owner: 'adobe',
+      branch: 'staging',
+      esi: false,
+      plain: true,
+      root: '',
+      repo: 'theblog',
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.ok(res.body.toString().match(/hlx_fonts/));
+  });
+
+  it('adobe/theblog fonts get delivered with relative URL', async () => {
+    const res = await main({
+      ref: '7966963696682b955c13ac0cefb8ed9af065f66a',
+      package: '8c8a56985d9b2624d338e98af8ba8cf03124dc11',
+      path: '/en/publish/fonts.hlx/pnv6nym.css',
+      params: '',
+      owner: 'adobe',
+      branch: 'staging',
+      esi: false,
+      plain: true,
+      root: '',
+      repo: 'theblog',
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.ok(res.body.toString().match(/fonts\.hlx/));
+  });
+});
+
 describe('Static Delivery Action #online #integrationtest', () => {
   it('ferrumjsorg/index.html gets delivered', async () => {
     const res = await main({
@@ -107,5 +146,5 @@ describe('Static Delivery Action #online #integrationtest', () => {
     });
     assert.equal(res.statusCode, 307);
     assert.equal(res.headers.location, 'https://raw.githubusercontent.com/adobe/pages/cf9fe34edaf229c2a9e6a296420bef76bcc3d28/static/ete/hero-posters/hero_ps_pr_two.png');
-  });
+  }).timeout(10000);
 });

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -60,6 +60,40 @@ createTargets().forEach((target) => {
         });
     }).timeout(10000);
 
+    it('theblog/hlx_fonts/pnv6nym.css gets delivered', async () => {
+      let url;
+
+      await chai
+        .request(target.host())
+        .get(`${target.urlPath()}?owner=adobe&repo=theblog&ref=7966963696682b955c13ac0cefb8ed9af065f66a&path=/hlx_fonts/pnv6nym.css&branch=staging&params=`)
+        .then((response) => {
+          url = response.request.url;
+          expect(response).to.have.status(200);
+          expect(response.body.toString()).to.be.a('string').that.includes('/hlx_fonts/');
+        })
+        .catch((e) => {
+          e.message = `At ${url}\n      ${e.message}`;
+          throw e;
+        });
+    }).timeout(10000);
+
+    it('theblog/fonts.hlx/pnv6nym.css gets delivered', async () => {
+      let url;
+
+      await chai
+        .request(target.host())
+        .get(`${target.urlPath()}?owner=adobe&repo=theblog&ref=7966963696682b955c13ac0cefb8ed9af065f66a&path=/en/publish/fonts.hlx/pnv6nym.css&branch=staging&params=`)
+        .then((response) => {
+          url = response.request.url;
+          expect(response).to.have.status(200);
+          expect(response.body.toString()).to.be.a('string').that.includes('/fonts.hlx/');
+        })
+        .catch((e) => {
+          e.message = `At ${url}\n      ${e.message}`;
+          throw e;
+        });
+    }).timeout(10000);
+
     it('pages/icons.svg gets delivered', async () => {
       let url;
       await chai

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -86,6 +86,7 @@ createTargets().forEach((target) => {
         .then((response) => {
           url = response.request.url;
           expect(response).to.have.status(200);
+          console.log(response.body);
           expect(response.body.toString()).to.be.a('string').that.includes('/fonts.hlx/');
         })
         .catch((e) => {

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -69,7 +69,7 @@ createTargets().forEach((target) => {
         .then((response) => {
           url = response.request.url;
           expect(response).to.have.status(200);
-          expect(response.body.toString()).to.be.a('string').that.includes('/hlx_fonts/');
+          expect(response.text).to.be.a('string').that.includes('/hlx_fonts/');
         })
         .catch((e) => {
           e.message = `At ${url}\n      ${e.message}`;
@@ -86,8 +86,8 @@ createTargets().forEach((target) => {
         .then((response) => {
           url = response.request.url;
           expect(response).to.have.status(200);
-          console.log(response.body);
-          expect(response.body.toString()).to.be.a('string').that.includes('/fonts.hlx/');
+
+          expect(response.text).to.be.a('string').that.includes('/fonts.hlx/');
         })
         .catch((e) => {
           e.message = `At ${url}\n      ${e.message}`;


### PR DESCRIPTION
Required for https://github.com/adobe/helix-publish/pull/718

This adds support for serving font css from `…/fonts.hlx/…` in addition to the existing delivery under `/hlx_fonts/…`