### PR TITLE
Icons anywhere (rootless icons)

### DIFF
--- a/src/handlers/github-icons.js
+++ b/src/handlers/github-icons.js
@@ -13,7 +13,8 @@ const { fetchFromGithub } = require('../github-fetcher');
 
 function handle(opts) {
   const iconopts = opts;
-  iconopts.path = `/icons/${opts.icon}.svg`;
+  iconopts.params.path = `/icons/${opts.params.icon}`;
+  iconopts.params.ext = 'svg';
   return fetchFromGithub(iconopts, null);
 }
 

--- a/src/handlers/github-icons.js
+++ b/src/handlers/github-icons.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const { fetchFromGithub } = require('../github-fetcher');
+
+function handle(opts) {
+  const iconopts = opts;
+  iconopts.path = `/icons/${opts.icon}.svg`;
+  return fetchFromGithub(iconopts, null);
+}
+
+module.exports = handle;

--- a/src/handlers/github-spritesheet.js
+++ b/src/handlers/github-spritesheet.js
@@ -13,7 +13,8 @@ const { fetchFromGithub } = require('../github-fetcher');
 
 function handle(opts) {
   const iconopts = opts;
-  iconopts.path = '/icons.svg';
+  iconopts.params.path = '/icons';
+  iconopts.params.ext = 'svg';
   return fetchFromGithub(iconopts, null);
 }
 

--- a/src/handlers/github-spritesheet.js
+++ b/src/handlers/github-spritesheet.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const { fetchFromGithub } = require('../github-fetcher');
+
+function handle(opts) {
+  const iconopts = opts;
+  iconopts.path = '/icons.svg';
+  return fetchFromGithub(iconopts, null);
+}
+
+module.exports = handle;

--- a/src/static.js
+++ b/src/static.js
@@ -16,6 +16,8 @@ const { Router } = require('./router');
 const { forbidden } = require('./utils');
 const fontCSS = require('./handlers/font-css');
 const githubPlain = require('./handlers/github-plain');
+const githubIcons = require('./handlers/github-icons');
+const githubSpritesheet = require('./handlers/github-spritesheet');
 const githubCSS = require('./handlers/github-css');
 const githubJS = require('./handlers/github-js');
 const pkgJson = require('../package.json');
@@ -107,6 +109,8 @@ async function deliverStatic(req, context) {
     .register('/hlx_fonts/:kitid([a-z0-9]{7}).css', fontCSS)
     .register(':path(.*).:ext(css)', githubCSS, isESI)
     .register(':path(.*).:ext(m?js)', githubJS, isESI)
+    .register(':prefix(.*)/_icons_.svg', githubSpritesheet)
+    .register(':prefix(.*)/_icons_:icon([a-zA-Z_-]+[a-zA-Z0-9]).svg', githubIcons)
     .register(':path(.*).:ext(.*)', githubPlain)
     .handle(file, params);
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -108,4 +108,32 @@ describe('Static Delivery Action #online #integrationtest', () => {
     assert.equal(res.statusCode, 307);
     assert.equal(res.headers.location, 'https://raw.githubusercontent.com/adobe/pages/cf9fe34edaf229c2a9e6a296420bef76bcc3d28/static/ete/hero-posters/hero_ps_pr_two.png');
   });
+
+  it('pages/icons.svg gets delivered', async () => {
+    const res = await main({
+      ref: '8664b440e94b217ed5da98dad1fd133e19cb3db2',
+      path: '/scripts/_icons_.svg',
+      owner: 'adobe',
+      esi: true,
+      plain: true,
+      root: '',
+      repo: 'pages',
+    });
+    assert.ok(res.body.indexOf('<?xml version="1.0" encoding="utf-8"?>') === 0);
+    assert.equal(res.statusCode, 200);
+  });
+
+  it('pages/icons/adobe.svg gets delivered', async () => {
+    const res = await main({
+      ref: '8664b440e94b217ed5da98dad1fd133e19cb3db2',
+      path: '/scripts/_icons_adobe.svg',
+      owner: 'adobe',
+      esi: true,
+      plain: true,
+      root: '',
+      repo: 'pages',
+    });
+    assert.ok(res.body.indexOf('<svg id="Layer_1" data-name="Layer 1"') === 0);
+    assert.equal(res.statusCode, 200);
+  });
 });

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -94,6 +94,23 @@ createTargets().forEach((target) => {
         });
     }).timeout(10000);
 
+    it('pages/icons.svg gets delivered as _icons_.svg', async () => {
+      let url;
+      await chai
+        .request(target.host())
+        .get(`${target.urlPath()}?owner=adobe&repo=pages&ref=d7acb4e41cf9546a40c7d6cd5e7162f8bcd540fd&path=/test/_icons_.svg`)
+        .then((response) => {
+          url = response.request.url;
+          expect(response).to.have.status(200);
+          expect(response).to.have.header('content-type', 'image/svg+xml');
+          expect(response.body.toString()).to.be.a('string').that.includes('<?xml version="1.0" encoding="utf-8"?>');
+        })
+        .catch((e) => {
+          e.message = `At ${url}\n      ${e.message}`;
+          throw e;
+        });
+    }).timeout(10000);
+
     it('helix-pages/htdocs/favicon.ico gets delivered', async () => {
       let url;
       await chai


### PR DESCRIPTION
See https://github.com/adobe/helix-publish/pull/718

Supports `*/_icons_*.svg`, but serves using the existing paths, so no breaking changes.